### PR TITLE
use sleep infinity instead of 1mio. seconds

### DIFF
--- a/120_kubernetes/kyverno/pod_security.demo
+++ b/120_kubernetes/kyverno/pod_security.demo
@@ -43,7 +43,7 @@ spec:
     image: busybox
     args:
     - sleep
-    - "1000000"
+    - infinity
     securityContext:
       allowPrivilegeEscalation: true
 EOF
@@ -61,7 +61,7 @@ spec:
     image: busybox
     args:
     - sleep
-    - "1000000"
+    - infinity
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -85,7 +85,7 @@ spec:
     image: bitnami/rabbitmq:latest
     args:
     - sleep
-    - "1000000"
+    - infinity
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -108,7 +108,7 @@ spec:
     image: busybox
     args:
     - sleep
-    - "1000000"
+    - infinity
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:


### PR DESCRIPTION
makes the yaml a bit more readable, and is actually an infinite sleep for the container (will not be restarted after 1mio. seconds)